### PR TITLE
Replace raven-go by sentry-go

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,6 +1,8 @@
 package zapsentry
 
 import (
+	"time"
+
 	"go.uber.org/zap/zapcore"
 )
 
@@ -9,4 +11,5 @@ type Configuration struct {
 	Tags              map[string]string
 	DisableStacktrace bool
 	Level             zapcore.Level
+	FlushTimeout      time.Duration
 }

--- a/factory.go
+++ b/factory.go
@@ -1,17 +1,21 @@
 package zapsentry
 
-import "github.com/getsentry/raven-go"
+import (
+	"github.com/getsentry/sentry-go"
+)
 
 func NewSentryClientFromDSN(DSN string) SentryClientFactory {
-	return func() (*raven.Client, error) {
-		return raven.New(DSN)
+	return func() (*sentry.Client, error) {
+		return sentry.NewClient(sentry.ClientOptions{
+			Dsn: DSN,
+		})
 	}
 }
 
-func NewSentryClientFromClient(client *raven.Client) SentryClientFactory {
-	return func() (*raven.Client, error) {
+func NewSentryClientFromClient(client *sentry.Client) SentryClientFactory {
+	return func() (*sentry.Client, error) {
 		return client, nil
 	}
 }
 
-type SentryClientFactory func() (*raven.Client, error)
+type SentryClientFactory func() (*sentry.Client, error)

--- a/severity.go
+++ b/severity.go
@@ -1,28 +1,28 @@
 package zapsentry
 
 import (
-	"github.com/getsentry/raven-go"
+	"github.com/getsentry/sentry-go"
 	"go.uber.org/zap/zapcore"
 )
 
-func ravenSeverity(lvl zapcore.Level) raven.Severity {
+func sentrySeverity(lvl zapcore.Level) sentry.Level {
 	switch lvl {
 	case zapcore.DebugLevel:
-		return raven.INFO
+		return sentry.LevelDebug
 	case zapcore.InfoLevel:
-		return raven.INFO
+		return sentry.LevelInfo
 	case zapcore.WarnLevel:
-		return raven.WARNING
+		return sentry.LevelWarning
 	case zapcore.ErrorLevel:
-		return raven.ERROR
+		return sentry.LevelError
 	case zapcore.DPanicLevel:
-		return raven.FATAL
+		return sentry.LevelFatal
 	case zapcore.PanicLevel:
-		return raven.FATAL
+		return sentry.LevelFatal
 	case zapcore.FatalLevel:
-		return raven.FATAL
+		return sentry.LevelFatal
 	default:
 		// Unrecognized levels are fatal.
-		return raven.FATAL
+		return sentry.LevelFatal
 	}
 }


### PR DESCRIPTION
As raven-go repo states its SDK is no longer maintained and was superseded by the sentry-go