### PR TITLE
copy flushTimeout across to new core

### DIFF
--- a/core.go
+++ b/core.go
@@ -100,6 +100,7 @@ func (c *core) with(fs []zapcore.Field) *core {
 	return &core{
 		client:       c.client,
 		cfg:          c.cfg,
+		flushTimeout: c.flushTimeout,
 		fields:       m,
 		LevelEnabler: c.LevelEnabler,
 	}


### PR DESCRIPTION
Fix issue where using .With resets the flushTimeout - so defaults to a 0 second timeout which loses fatal events. 

```
[Sentry] 2020/07/09 11:21:16 Sending fatal event [x] to o416843.ingest.sentry.io project: y
[Sentry] 2020/07/09 11:21:16 Buffer flushing reached the timeout.
```