### PR TITLE
Fix breadcrumbs when using a non-default hub

### DIFF
--- a/core.go
+++ b/core.go
@@ -18,12 +18,16 @@ const (
 	zapSentryScopeKey = "_zapsentry_scope_"
 )
 
-func NewScope() zapcore.Field {
+func NewScopeFromScope(scope *sentry.Scope) zapcore.Field {
 	f := zap.Skip()
-	f.Interface = sentry.NewScope()
+	f.Interface = scope
 	f.Key = zapSentryScopeKey
 
 	return f
+}
+
+func NewScope() zapcore.Field {
+	return NewScopeFromScope(sentry.NewScope())
 }
 
 func NewCore(cfg Configuration, factory SentryClientFactory) (zapcore.Core, error) {


### PR DESCRIPTION
It works when explicitly creating a scope with `log.With(zapsentry.NewScope())`, but doing so loses the information tied to the hub (e.g. the `http.Request` info when using https://docs.sentry.io/platforms/go/guides/http/).

This PR makes it no that hub's scope is used when adding breadcrumbs.

This also removes the need to manually create a scope to use the breadcrumbs feature.