### PR TITLE
Add tags in sending logs

### DIFF
--- a/core.go
+++ b/core.go
@@ -94,9 +94,11 @@ func (c *core) Write(ent zapcore.Entry, fs []zapcore.Field) error {
 
 	if c.cfg.Level.Enabled(ent.Level) {
 		tagsCount := len(c.cfg.Tags)
-		for k, _ := range clone.fields {
-			if strings.HasPrefix(k, "tag:") && len(k) > 4 {
-				tagsCount++
+		for _, f := range fs {
+			if f.Type == zapcore.SkipType {
+				if _, ok := f.Interface.(tagField); ok {
+					tagsCount++
+				}
 			}
 		}
 
@@ -109,10 +111,10 @@ func (c *core) Write(ent zapcore.Entry, fs []zapcore.Field) error {
 		for k, v := range c.cfg.Tags {
 			event.Tags[k] = v
 		}
-		for k, v := range clone.fields {
-			if strings.HasPrefix(k, "tag:") && len(k) > 4 {
-				if s, ok := v.(string); ok {
-					event.Tags[strings.TrimPrefix(k, "tag:")] = s
+		for _, f := range fs {
+			if f.Type == zapcore.SkipType {
+				if t, ok := f.Interface.(tagField); ok {
+					event.Tags[t.Key] = t.Value
 				}
 			}
 		}

--- a/example_logger_test.go
+++ b/example_logger_test.go
@@ -44,15 +44,17 @@ func ExampleAttachCoreToLogger() {
 	// Send error log
 	newLogger.
 		With(zapsentry.NewScope()).
-		Error("[error] something went wrong!", zap.String("method", "unknown"))
+		Error("[error] something went wrong!", zap.String("method", "unknown"), zap.String("tag:service", "app"))
 
 	// Check output
 	fmt.Println(recordedLogs.All()[0].Message)
 	fmt.Println(recordedSentryEvent.Message)
 	fmt.Println(recordedSentryEvent.Extra)
+	fmt.Println(recordedSentryEvent.Tags)
 	// Output: [error] something went wrong!
 	// [error] something went wrong!
-	// map[method:unknown]
+	// map[method:unknown tag:service:app]
+	// map[component:system service:app]
 }
 
 func mockSentryClient(f func(event *sentry.Event)) *sentry.Client {
@@ -79,4 +81,3 @@ func (f *transport) Configure(_ sentry.ClientOptions) {}
 func (f *transport) SendEvent(event *sentry.Event) {
 	f.MockSendEvent(event)
 }
-

--- a/example_logger_test.go
+++ b/example_logger_test.go
@@ -44,7 +44,7 @@ func ExampleAttachCoreToLogger() {
 	// Send error log
 	newLogger.
 		With(zapsentry.NewScope()).
-		Error("[error] something went wrong!", zap.String("method", "unknown"), zap.String("tag:service", "app"))
+		Error("[error] something went wrong!", zap.String("method", "unknown"), zapsentry.Tag("service", "app"))
 
 	// Check output
 	fmt.Println(recordedLogs.All()[0].Message)
@@ -53,7 +53,7 @@ func ExampleAttachCoreToLogger() {
 	fmt.Println(recordedSentryEvent.Tags)
 	// Output: [error] something went wrong!
 	// [error] something went wrong!
-	// map[method:unknown tag:service:app]
+	// map[method:unknown]
 	// map[component:system service:app]
 }
 

--- a/field.go
+++ b/field.go
@@ -1,0 +1,15 @@
+package zapsentry
+
+import (
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+type tagField struct {
+	Key   string
+	Value string
+}
+
+func Tag(key string, value string) zap.Field {
+	return zap.Field{Key: key, Type: zapcore.SkipType, Interface: tagField{key, value}}
+}


### PR DESCRIPTION
The PR adds support to add tags in sending logs. I think this feature is useful to add a request id tag for searching, for example.