### PR TITLE
add support for changing levels at runtime

### DIFF
--- a/config.go
+++ b/config.go
@@ -22,7 +22,7 @@ type Configuration struct {
 	DisableStacktrace bool
 
 	// Level is the minimal level of sentry.Event(s).
-	Level zapcore.Level
+	Level zapcore.LevelEnabler
 
 	// EnableBreadcrumbs enables use of sentry.Breadcrumb(s).
 	// This feature works only when you explicitly passed new scope.
@@ -32,7 +32,7 @@ type Configuration struct {
 	// Breadcrumb specifies an application event that occurred before a Sentry event.
 	// NewCore fails if BreadcrumbLevel is greater than Level.
 	// The field is ignored, if EnableBreadcrumbs is not set.
-	BreadcrumbLevel zapcore.Level
+	BreadcrumbLevel zapcore.LevelEnabler
 
 	// MaxBreadcrumbs is the maximum number of breadcrumb events to keep.
 	// Leave it zero or set to negative for a reasonable default value.

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,60 @@
+package zapsentry_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/getsentry/sentry-go"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/TheZeroSlave/zapsentry"
+)
+
+func TestLevelEnabler(t *testing.T) {
+	lvl := zap.NewAtomicLevelAt(zap.PanicLevel)
+	core, recordedLogs := observer.New(lvl)
+	logger := zap.New(core)
+
+	var recordedSentryEvent *sentry.Event
+	sentryClient := mockSentryClient(func(event *sentry.Event) {
+		recordedSentryEvent = event
+	})
+
+	core, err := zapsentry.NewCore(
+		zapsentry.Configuration{Level: lvl},
+		zapsentry.NewSentryClientFromClient(sentryClient),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newLogger := zapsentry.AttachCoreToLogger(core, logger)
+
+	newLogger.Error("foo")
+	if recordedLogs.Len() > 0 || recordedSentryEvent != nil {
+		t.Errorf("expected no logs before level change")
+		t.Logf("logs=%v", recordedLogs.All())
+		t.Logf("events=%v", recordedSentryEvent)
+	}
+
+	lvl.SetLevel(zap.ErrorLevel)
+	newLogger.Error("bar")
+	if recordedLogs.Len() != 1 || recordedSentryEvent == nil {
+		t.Errorf("expected exactly one log after level change")
+		t.Logf("logs=%v", recordedLogs.All())
+		t.Logf("events=%v", recordedSentryEvent)
+	}
+}
+
+func TestBreadcrumbLevelEnabler(t *testing.T) {
+	corelvl := zap.NewAtomicLevelAt(zap.ErrorLevel)
+	breadlvl := zap.NewAtomicLevelAt(zap.PanicLevel)
+
+	_, err := zapsentry.NewCore(
+		zapsentry.Configuration{Level: corelvl, BreadcrumbLevel: breadlvl, EnableBreadcrumbs: true},
+		zapsentry.NewSentryClientFromClient(mockSentryClient(func(event *sentry.Event) {})),
+	)
+	if !errors.Is(err, zapsentry.ErrInvalidBreadcrumbLevel) {
+		t.Errorf("expected ErrInvalidBreadcrumbLevel, got %v", err)
+	}
+}


### PR DESCRIPTION
this allows configuring zapsentry with other zap.LevelEnabler implmentations (namely, zap.AtomicLevel) which makes it easy to change Sentry reporting threshold at runtime, without re–creating logger and/or core objects

since various zap.*Level consts are also LevelEnablers, this change is backwards compatible