### PR TITLE
Add support for breadcrumbs without scope

### DIFF
--- a/config.go
+++ b/config.go
@@ -28,6 +28,10 @@ type Configuration struct {
 	// This feature works only when you explicitly passed new scope.
 	EnableBreadcrumbs bool
 
+	// If you cannot (or don't want to) create a local scope for breadcrumbs
+	// you an disable the default behavior of ignoring the global scope
+	EnableBreadcrumbsInGlobalScope bool
+
 	// BreadcrumbLevel is the minimal level of sentry.Breadcrumb(s).
 	// Breadcrumb specifies an application event that occurred before a Sentry event.
 	// NewCore fails if BreadcrumbLevel is greater than Level.

--- a/core.go
+++ b/core.go
@@ -139,7 +139,7 @@ func (c *core) Write(ent zapcore.Entry, fs []zapcore.Field) error {
 	clone := c.with(c.addSpecialFields(ent, fs))
 
 	// only when we have local sentryScope to avoid collecting all breadcrumbs ever in a global scope
-	if c.cfg.EnableBreadcrumbs && c.cfg.BreadcrumbLevel.Enabled(ent.Level) && c.sentryScope != nil {
+	if c.cfg.EnableBreadcrumbs && c.cfg.BreadcrumbLevel.Enabled(ent.Level) && (c.sentryScope != nil || c.cfg.EnableBreadcrumbsInGlobalScope) {
 		breadcrumb := sentry.Breadcrumb{
 			Message:   ent.Message,
 			Data:      clone.fields,
@@ -147,7 +147,7 @@ func (c *core) Write(ent zapcore.Entry, fs []zapcore.Field) error {
 			Timestamp: ent.Time,
 		}
 
-		c.sentryScope.AddBreadcrumb(&breadcrumb, c.cfg.MaxBreadcrumbs)
+		c.scope().AddBreadcrumb(&breadcrumb, c.cfg.MaxBreadcrumbs)
 	}
 
 	if c.cfg.Level.Enabled(ent.Level) {


### PR DESCRIPTION
I am working on a component where I cannot define a scope (as the Zap logger is wrapped into further abstraction that I cannot unwrap to add a scope). To work around that I am adding an option to disable the "no breadcrumbs in global scope" rule if needed (I think the rule is a good idea, just really can't use it otherwise).

What do you think?