### PR TITLE
Use scope() instead of sentryScope directly when adding breadcrumbs.

### DIFF
--- a/core.go
+++ b/core.go
@@ -139,7 +139,7 @@ func (c *core) Write(ent zapcore.Entry, fs []zapcore.Field) error {
 	clone := c.with(c.addSpecialFields(ent, fs))
 
 	// only when we have local sentryScope to avoid collecting all breadcrumbs ever in a global scope
-	if c.cfg.EnableBreadcrumbs && c.cfg.BreadcrumbLevel.Enabled(ent.Level) && c.sentryScope != nil {
+	if c.cfg.EnableBreadcrumbs && c.cfg.BreadcrumbLevel.Enabled(ent.Level) && c.scope() != nil {
 		breadcrumb := sentry.Breadcrumb{
 			Message:   ent.Message,
 			Data:      clone.fields,
@@ -147,7 +147,7 @@ func (c *core) Write(ent zapcore.Entry, fs []zapcore.Field) error {
 			Timestamp: ent.Time,
 		}
 
-		c.sentryScope.AddBreadcrumb(&breadcrumb, c.cfg.MaxBreadcrumbs)
+		c.scope().AddBreadcrumb(&breadcrumb, c.cfg.MaxBreadcrumbs)
 	}
 
 	if c.cfg.Level.Enabled(ent.Level) {


### PR DESCRIPTION
I'd love to be able to use `sentry.configureScope` normally and have breadcrumbs enabled. Right now it isn't possible because breadcrumbs require a "special" sentry scope to be set in zap fields (`log.With(zapsentry.NewScope())`), and `configureScope` does not configure that scope so, for instance, the tags set are not sent to sentry.

Using `scope()` instead of `sentryScope` directly fixes this. Now, we can just use a regular sentry scope and `configureScope` will work.