### PR TITLE
fix: use module matching to filter out zap

### DIFF
--- a/frame_matcher.go
+++ b/frame_matcher.go
@@ -20,7 +20,7 @@ type FrameMatcher interface {
 var (
 	defaultFrameMatchers = FrameMatchers{
 		SkipModulePrefixFrameMatcher("github.com/TheZeroSlave/zapsentry"),
-		SkipFunctionPrefixFrameMatcher("go.uber.org/zap"),
+		SkipModulePrefixFrameMatcher("go.uber.org/zap"),
 	}
 )
 

--- a/frame_matcher_test.go
+++ b/frame_matcher_test.go
@@ -51,7 +51,7 @@ func Test_core_filterFrames(t *testing.T) {
 			args: args{
 				[]sentry.Frame{
 					{
-						Function: "go.uber.org/zap/String",
+						Module: "go.uber.org/zap",
 					},
 				},
 			},


### PR DESCRIPTION
The sentry.Frame.Function does not include the package[0], so it's unclear how (or if) this ever worked.

The link points to the vesion currently used in go.mod, but newer versions also show the same behavior.

[0] https://github.com/getsentry/sentry-go/blob/a929b08edd1f4aa6e281ed699432be6e3f415713/stacktrace.go#L221