### PR TITLE
Add cleanFrames method call to existing stacktraces frames

### DIFF
--- a/core.go
+++ b/core.go
@@ -219,7 +219,10 @@ func (c *core) addExceptionsFromError(
 		exception := sentry.Exception{Value: err.Error(), Type: getTypeName(err)}
 
 		if !c.cfg.DisableStacktrace {
-			exception.Stacktrace = sentry.ExtractStacktrace(err)
+			stacktrace := sentry.ExtractStacktrace(err)
+			stacktrace.Frames = c.filterFrames(stacktrace.Frames)
+
+			exception.Stacktrace = stacktrace
 		}
 
 		exceptions = append(exceptions, exception)


### PR DESCRIPTION
If we extract stacktrace from an error, we should to filter its frames as well.
Currently zapsentry modules (or any other modules defined in custom FrameMatchers) are not cleaning from the stacktrace.