### PR TITLE
check for nil stacktrace before clean frames

### DIFF
--- a/core.go
+++ b/core.go
@@ -220,7 +220,9 @@ func (c *core) addExceptionsFromError(
 
 		if !c.cfg.DisableStacktrace {
 			stacktrace := sentry.ExtractStacktrace(err)
-			stacktrace.Frames = c.filterFrames(stacktrace.Frames)
+			if stacktrace != nil {
+				stacktrace.Frames = c.filterFrames(stacktrace.Frames)
+			}
 
 			exception.Stacktrace = stacktrace
 		}


### PR DESCRIPTION
Due to lack of unit tests, I skip the case when stacktrace could be nil after extraction

Suggest: add unit tests for core.go